### PR TITLE
fixed includes and max fps == 30 issue

### DIFF
--- a/source/platform.cpp
+++ b/source/platform.cpp
@@ -3,7 +3,7 @@
 #include <sys/unistd.h>
 #include <fcntl.h>
 #include <algorithm>
-
+#include <string.h>
 #include <3ds.h>
 
 #include "platform.h"
@@ -190,10 +190,9 @@ bool screen_end_draw() {
 }
 
 void screen_swap_buffers() {
+	gspWaitForVBlank();//has to be called before flushing
 	gfxFlushBuffers();
 	gfxSwapBuffers();
-	gspWaitForVBlank();
-	platform_delay(1); // Seems to help with flickering.
 }
 
 int screen_get_width() {


### PR DESCRIPTION
- string.h is needed for some functions here, it's not included with 3ds.h anymore
- you have to wait for the vblank before asking for a flush of the buffers, you were missing 1vblank because of this